### PR TITLE
Add condition for source-posts on Pleroma

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -46,7 +46,14 @@ export default class Mastodon extends HTMLElement {
   async fetchComments(url) {
     const tootUrl = new URL(url);
     const { origin, pathname } = tootUrl;
-    const [_, id] = pathname.match(/\/(\d+)$/);
+
+    let [_, id] = pathname.match(/\/(\d+)$/);
+
+    // In case it’s a a Pleroma server, with /notice/ URLs.
+      if (pathname.includes("/notice/")) {
+        [, id] = pathname.match(/^\/notice\/([^\/?#]+)/);
+    }
+
     const data = await Mastodon.fetch(
       new URL(`${origin}/api/v1/statuses/${id}/context`),
       Number(this.getAttribute("cache") || 0),


### PR DESCRIPTION
This works perfectly on Pleroma, but for that Pleroma’s post URLs are in a slightly different format (/notice/ followed by several alphanums, rather than /@username/ followed by several numbers). This just adds a condition to support Pleroma posts.